### PR TITLE
feat: allow adding optional line classes

### DIFF
--- a/test/test.ts
+++ b/test/test.ts
@@ -76,3 +76,17 @@ it('has proper encoding', async () => {
     `"<pre class=\\"shiki\\" style=\\"background-color: #2e3440ff\\"><code><span class=\\"line\\"><span style=\\"color: #81A1C1\\">&#x3C;div></span></span><br><span class=\\"line\\"><span style=\\"color: #D8DEE9FF\\">      </span><span style=\\"color: #81A1C1\\">&#x3C;span></span><span style=\\"color: #D8DEE9FF\\">hello</span><span style=\\"color: #81A1C1\\">&#x3C;/span></span></span><br><span class=\\"line\\"><span style=\\"color: #D8DEE9FF\\">    </span><span style=\\"color: #81A1C1\\">&#x3C;/div></span></span></code></pre>"`
   )
 })
+
+it('adds optional line classes', () => {
+  const tree = codeToHast(
+    globalHighlighter,
+    'const test = () => {\n  console.log("Hello World!")\n}',
+    'js',
+    undefined,
+    { lineOptions: [{ line: 2, classes: ['highlighted'] }] }
+  )
+
+  expect(toHtml(tree)).toMatchInlineSnapshot(
+    `"<pre class=\\"shiki\\" style=\\"background-color: #2e3440ff\\"><code><span class=\\"line\\"><span style=\\"color: #81A1C1\\">const</span><span style=\\"color: #D8DEE9FF\\"> </span><span style=\\"color: #88C0D0\\">test</span><span style=\\"color: #D8DEE9FF\\"> </span><span style=\\"color: #81A1C1\\">=</span><span style=\\"color: #D8DEE9FF\\"> </span><span style=\\"color: #ECEFF4\\">()</span><span style=\\"color: #D8DEE9FF\\"> </span><span style=\\"color: #81A1C1\\">=></span><span style=\\"color: #D8DEE9FF\\"> </span><span style=\\"color: #ECEFF4\\">{</span></span><br><span class=\\"line highlighted\\"><span style=\\"color: #D8DEE9FF\\">  </span><span style=\\"color: #D8DEE9\\">console</span><span style=\\"color: #ECEFF4\\">.</span><span style=\\"color: #88C0D0\\">log</span><span style=\\"color: #D8DEE9FF\\">(</span><span style=\\"color: #ECEFF4\\">\\"</span><span style=\\"color: #A3BE8C\\">Hello World!</span><span style=\\"color: #ECEFF4\\">\\"</span><span style=\\"color: #D8DEE9FF\\">)</span></span><br><span class=\\"line\\"><span style=\\"color: #ECEFF4\\">}</span></span></code></pre>"`
+  )
+})


### PR DESCRIPTION
hi, shiki v0.10 has added the option to add additional classes to specific lines. in case this is something you want to support in the `hast` renderer as well, this adds that (most stuff is just copied over from https://github.com/shikijs/shiki/blob/main/packages/shiki/src/renderer.ts). thanks!